### PR TITLE
Add lint and fix scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "scripts": {
         "start": "ts-node index.ts",
         "test": "jest",
+        "lint": "eslint --ext .ts . && prettier . --check",
+        "fix": "eslint --ext .ts . --fix && prettier . --write",
         "build": "tsc"
     },
     "repository": {


### PR DESCRIPTION
I thought these two scripts would be handy. The `lint` script just runs eslint and preittier to look for problems. The `fix` script runs both tools again but tries to fix what it can (option for those who may not have auto-format capabilities available in their IDE).