### PR TITLE
Write ADR for converting tests from jest to native

### DIFF
--- a/adrs/001-use-adrs.md
+++ b/adrs/001-use-adrs.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Approved
+Implemented
 
 ## Context
 

--- a/adrs/002-copy-signify-ts-as-initial-commit.md
+++ b/adrs/002-copy-signify-ts-as-initial-commit.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Approved
+Implemented
 
 ## Context
 

--- a/adrs/003-convert-jest-tests-to-native-runner.md
+++ b/adrs/003-convert-jest-tests-to-native-runner.md
@@ -1,0 +1,21 @@
+# [003] - Convert Jest tests to native Node.js test runner
+
+## Status
+
+Proposed
+
+## Context
+
+Node.js has had a built-in test runner since v18. The docs are found [here](https://nodejs.org/api/test.html). Jest is a fairly heavy dependency and it has had some maintenance issues in recent years.
+
+## Decision
+
+To remove dependencies where possible and to adjust to convention: Rewrite existing tests to run with the native runner and eliminate Jest.
+
+## Consequences
+
+The native test runner does require the specification of a module loader to run typescript files directly, but it is [straightforward to fix](https://glebbahmutov.com/blog/trying-node-test-runner/#typescript).
+
+## Other Options Considered
+
+Sticking with Jest.


### PR DESCRIPTION
Here's the ADR for migrating tests from Jest to the native node.js runner. fixes #19 