### PR TITLE
Fix failing quality check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,1 @@
-// to be filled in with the api
 console.log('TypeScript-native implementation of CESR primitives!');

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
+// to be filled in with the api
 console.log('TypeScript-native implementation of CESR primitives!');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "description": "Implement TypeScript-native CESR primitives.",
     "main": "index.js",
-   "scripts": {
+    "scripts": {
         "start": "ts-node index.ts",
         "test": "node --test --require ts-node/register **/*.test.ts",
         "formatting": "prettier . --check",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
    "scripts": {
         "start": "ts-node index.ts",
-        "test": "jest",
+        "test": "node --test --require ts-node/register **/*.test.ts",
         "formatting": "prettier . --check",
         "lint": "eslint --ext .ts .",
         "fix-lint": "eslint --ext .ts . --fix",


### PR DESCRIPTION
This will fix the failing quality check. The problem had to do with the merge where the `npm test` script was accidentally reverted to `jest`. All checks pass again now. fixes #28 